### PR TITLE
support quoted list of space-delimited granules provided by HyP3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2]
+
+### Fixed
+* `back_project` granules parameter so that it can accept a string of space-delimited granule names.
+
 ## [0.5.1]
 
 ### Fixed

--- a/src/hyp3_back_projection/back_projection.py
+++ b/src/hyp3_back_projection/back_projection.py
@@ -165,7 +165,7 @@ def main():
     parser.add_argument('--gpu', default=False, action='store_true', help='Use the GPU-based version of the workflow.')
     parser.add_argument('granules', type=str.split, nargs='+', help='Level-0 S1 granule(s) to back-project.')
     args = parser.parse_args()
-
+    args.granules = [item for sublist in args.granules for item in sublist]
     back_project(**args.__dict__)
 
 

--- a/src/hyp3_back_projection/back_projection.py
+++ b/src/hyp3_back_projection/back_projection.py
@@ -163,7 +163,7 @@ def main():
     parser.add_argument('--bucket', help='AWS S3 bucket HyP3 for upload the final product(s)')
     parser.add_argument('--bucket-prefix', default='', help='Add a bucket prefix to product(s)')
     parser.add_argument('--gpu', default=False, action='store_true', help='Use the GPU-based version of the workflow.')
-    parser.add_argument('granules', nargs='+', help='Level-0 S1 granule to back-project.')
+    parser.add_argument('granules', type=str.split, nargs='+', help='Level-0 S1 granule(s) to back-project.')
     args = parser.parse_args()
 
     back_project(**args.__dict__)


### PR DESCRIPTION
Borrowed from the INSAR_GAMMA job type at https://github.com/ASFHyP3/hyp3-gamma/blob/develop/hyp3_gamma/__main__.py#L161

HyP3 provides mutli-value parameters as a single space-delimited string, e.g.:
```
docker run hyp3-back-projection --granules "foo bar"
```

`type=str.split` coerces args.granules back into a list, in this case ['foo', 'bar']. Providing multiple values should still work as expected, e.g. these should all produce the same results:

```
docker run hyp3-back-projection --granules "foo bar"
docker run hyp3-back-projection --granules foo bar
docker run hyp3-back-projection --granules "foo" "bar"
```