### PR TITLE
job submission: --bbox for minmax latlon; --wkt for WKT; --name for job name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1]
+
+### Added
+* Added new parameters from v0.10.0 to `submit_time_series_job` script.
+* Added `--wkt` parameter to find bounds from a WKT Polygon.
+* Added `--bbox` parameter to pass regular bounding box instead of WKT Polygon.
+* Added `--name` parameter to customize the job name.
+
 ## [0.10.0]
 
 ### Added

--- a/scripts/submit_time_series_job.py
+++ b/scripts/submit_time_series_job.py
@@ -111,7 +111,7 @@ def get_args():
     parser.add_argument('--bucket', help='Bucket Name')
     parser.add_argument(
         '--bucket-prefix',
-        help="Bucket prefix job products will be written to. The argument will be ignored if `--bucket` isn't provided. This argument also allows expansion of job name or job id by using `{name}` and `{job_id}` if contained within the string.",
+        help="Bucket prefix job products will be written to. The argument will be ignored if `--bucket` isn't provided. This argument also allows expansion of job name or job id by using `{name}` and `{job_id}` within the string.",
     )
     parser.add_argument('--process', choices=['sbas', 'ps'], default='sbas', help='Processing strategy (sbas or ps)')
     parser.add_argument('--tbaseline', default=1000, help='Temporal baseline')

--- a/scripts/submit_time_series_job.py
+++ b/scripts/submit_time_series_job.py
@@ -111,11 +111,11 @@ def get_args():
     parser.add_argument('--bucket', help='Bucket Name')
     parser.add_argument(
         '--bucket-prefix',
-        help="Bucket prefix job products will be written to. The argument will be ignored if `--bucket` isn't provided. This argument also allows expansion of job name or job id by using `{name}` and `{job_id}` within the string.",
+        help="Bucket prefix job products will be written to. The argument will be ignored if `--bucket` isn't provided. This argument also allows expansion of job name or job id by using `{name}` and `{job_id}` if contained within the string.",
     )
     parser.add_argument('--process', choices=['sbas', 'ps'], default='sbas', help='Processing strategy (sbas or ps)')
-    parser.add_argument('--tbaseline', default=1000, help='Temporal baseline')
-    parser.add_argument('--pbaseline', default=60, help='Perpendicular baseline')
+    parser.add_argument('--tbaseline', type=int, default=60, help='Temporal baseline')
+    parser.add_argument('--pbaseline', type=int, default=1000, help='Perpendicular baseline')
     parser.add_argument(
         '--hyp3-deployment',
         choices=['hyp3-lavas', 'hyp3-lavas-test'],

--- a/scripts/submit_time_series_job.py
+++ b/scripts/submit_time_series_job.py
@@ -70,7 +70,7 @@ def submit_job(
     if name is not None:
         prepared_job['name'] = name
     if bucket is not None:
-        prepared_job['bucket'] =  bucket
+        prepared_job['bucket'] = bucket
         if bucket_prefix is not None:
             prepared_job['bucket_prefix'] = bucket_prefix
     return hyp3.submit_prepared_jobs(prepared_job)[0]
@@ -109,8 +109,11 @@ def get_args():
     # Optional arguments
     parser.add_argument('--name', help='Name for the job')
     parser.add_argument('--bucket', help='Bucket Name')
-    parser.add_argument('--bucket-prefix', help='Bucket prefix')
-    parser.add_argument('--process', default='sbas', help='Processing strategy (sbas or ps)')
+    parser.add_argument(
+        '--bucket-prefix',
+        help="Bucket prefix job products will be written to. The argument will be ignored if `--bucket` isn't provided. This argument also allows expansion of job name or job id by using `{name}` and `{job_id}` if contained within the string.",
+    )
+    parser.add_argument('--process', choices=['sbas', 'ps'], default='sbas', help='Processing strategy (sbas or ps)')
     parser.add_argument('--tbaseline', default=1000, help='Temporal baseline')
     parser.add_argument('--pbaseline', default=60, help='Perpendicular baseline')
     parser.add_argument(

--- a/scripts/submit_time_series_job.py
+++ b/scripts/submit_time_series_job.py
@@ -69,6 +69,10 @@ def submit_job(
     }
     if name is not None:
         prepared_job['name'] = name
+    if bucket is not None:
+        prepared_job['bucket'] =  bucket
+        if bucket_prefix is not None:
+            prepared_job['bucket_prefix'] = bucket_prefix
     return hyp3.submit_prepared_jobs(prepared_job)[0]
 
 

--- a/scripts/submit_time_series_job.py
+++ b/scripts/submit_time_series_job.py
@@ -3,18 +3,18 @@ import argparse
 import asf_search
 import hyp3_sdk
 
+
 def wkt_to_bbox(wkt: str) -> tuple[float, float, float, float]:
     """Extract bounding box from WKT POLYGON string.
     Returns: (min_lon, min_lat, max_lon, max_lat)
     """
     if not wkt.startswith('POLYGON((') or not wkt.endswith('))'):
         raise ValueError('WKT must be a POLYGON')
-    
+
     # Extract coordinate pairs
     points_str = wkt[9:-2]  # Strip 'POLYGON((' and '))'
-    coords = [tuple(map(float, point.strip().split())) 
-              for point in points_str.split(',')]
-    
+    coords = [tuple(map(float, point.strip().split())) for point in points_str.split(',')]
+
     lons, lats = zip(*coords)
     return min(lons), min(lats), max(lons), max(lats)
 
@@ -40,19 +40,47 @@ def get_granules(
         )
         granules.extend(result.properties['sceneName'] for result in results)
     return granules
-        
+
 
 def submit_job(
-    granules: list[str], min_lon: float, min_lat: float, max_lon: float, max_lat: float, hyp3_url: str, name: str | None = None,
+    granules: list[str],
+    min_lon: float,
+    min_lat: float,
+    max_lon: float,
+    max_lat: float,
+    hyp3_url: str,
+    process: str,
+    tbaseline: int,
+    pbaseline: int,
+    name: str | None = None,
+    bucket: str | None = None,
+    bucket_prefix: str | None = None,
 ) -> hyp3_sdk.Job:
     hyp3 = hyp3_sdk.HyP3(hyp3_url)
-    prepared_job = {
-        'job_type': 'SRG_TIME_SERIES',
-        'job_parameters': {
-            'granules': granules,
-            'bounds': [min_lon, min_lat, max_lon, max_lat],
-        },
-    }
+    if bucket is None:
+        prepared_job = {
+            'job_type': 'SRG_TIME_SERIES',
+            'job_parameters': {
+                'granules': granules,
+                'bounds': [min_lon, min_lat, max_lon, max_lat],
+                'process': process,
+                'tbaseline': tbaseline,
+                'pbaseline': pbaseline,
+            },
+        }
+    else:
+        prepared_job = {
+            'job_type': 'SRG_TIME_SERIES',
+            'job_parameters': {
+                'granules': granules,
+                'bounds': [min_lon, min_lat, max_lon, max_lat],
+                'process': process,
+                'tbaseline': tbaseline,
+                'pbaseline': pbaseline,
+                'bucket': bucket,
+                'bucket_prefix': bucket_prefix,
+            },
+        }
     if name is not None:
         prepared_job['name'] = name
     return hyp3.submit_prepared_jobs(prepared_job)[0]
@@ -61,16 +89,16 @@ def submit_job(
 def get_args():
     parser = argparse.ArgumentParser(
         description='Submit time series job to HyP3',
-        epilog='''
+        epilog="""
   Examples:
   # Using bounding box:
   python submit_time_series_job.py 50 2023-01-01 2023-02-01 --bbox -120.0 35.0 -119.0 36.0 --name "KernCounty-Asc050"
   
   # Using WKT polygon:
   python submit_time_series_job.py 50 2023-01-01 2023-02-01 --wkt "POLYGON((-120.0 35.0, -119.0 35.0, -119.0 36.0, -120.0 36.0, -120.0 35.0))"
-        ''',
-        formatter_class=argparse.RawDescriptionHelpFormatter
-    )    
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
 
     # Required positional arguments
     parser.add_argument('path', type=int, help='Path/track number, 1-175')
@@ -79,13 +107,22 @@ def get_args():
 
     # Mutually exclusive spatial definition
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('--bbox', nargs=4, type=float,
+    group.add_argument(
+        '--bbox',
+        nargs=4,
+        type=float,
         metavar=('MIN_LON', 'MIN_LAT', 'MAX_LON', 'MAX_LAT'),
-        help='Bounding box as four floats: min_lon min_lat max_lon max_lat',)
+        help='Bounding box as four floats: min_lon min_lat max_lon max_lat',
+    )
     group.add_argument('--wkt', help='WKT string for the area of interest')
 
     # Optional arguments
     parser.add_argument('--name', help='Name for the job')
+    parser.add_argument('--bucket', help='Bucket Name')
+    parser.add_argument('--bucket-prefix', help='Bucket prefix')
+    parser.add_argument('--process', default='sbas', help='Processing strategy (sbas or ps)')
+    parser.add_argument('--tbaseline', default=1000, help='Temporal baseline')
+    parser.add_argument('--pbaseline', default=60, help='Perpendicular baseline')
     parser.add_argument(
         '--hyp3-deployment',
         choices=['hyp3-lavas', 'hyp3-lavas-test'],
@@ -104,8 +141,8 @@ def main():
         args.min_lon, args.min_lat, args.max_lon, args.max_lat = wkt_to_bbox(args.wkt)
     else:
         args.min_lon, args.min_lat, args.max_lon, args.max_lat = args.bbox
-            
-    print(f'Processing configuration:')
+
+    print('Processing configuration:')
     print(f'  Path: {args.path}')
     print(f'  Date range: {args.start} to {args.end}')
     print(f'  Bounding box: ({args.min_lon:.4f}, {args.min_lat:.4f}) to ({args.max_lon:.4f}, {args.max_lat:.4f})')
@@ -121,9 +158,24 @@ def main():
         raise ValueError('No granules found for these search criteria')
 
     hyp3_url = f'https://{args.hyp3_deployment}.asf.alaska.edu'
-    job = submit_job(granule_names, args.min_lon, args.min_lat, args.max_lon, args.max_lat, hyp3_url, args.name)
+    job = submit_job(
+        granule_names,
+        args.min_lon,
+        args.min_lat,
+        args.max_lon,
+        args.max_lat,
+        hyp3_url,
+        args.process,
+        args.tbaseline,
+        args.pbaseline,
+        args.name,
+        args.bucket,
+        args.bucket_prefix,
+    )
 
-    print(f'\nJob {job.job_id}, Name: {job.name}, submitted to {args.hyp3_deployment} for {len(granule_names)} granules')
+    print(
+        f'\nJob {job.job_id}, Name: {job.name}, submitted to {args.hyp3_deployment} for {len(granule_names)} granules'
+    )
 
     print(f'\n{hyp3_url}/jobs/{job.job_id}')
     print('\nimport hyp3_sdk')

--- a/scripts/submit_time_series_job.py
+++ b/scripts/submit_time_series_job.py
@@ -57,30 +57,16 @@ def submit_job(
     bucket_prefix: str | None = None,
 ) -> hyp3_sdk.Job:
     hyp3 = hyp3_sdk.HyP3(hyp3_url)
-    if bucket is None:
-        prepared_job = {
-            'job_type': 'SRG_TIME_SERIES',
-            'job_parameters': {
-                'granules': granules,
-                'bounds': [min_lon, min_lat, max_lon, max_lat],
-                'process': process,
-                'tbaseline': tbaseline,
-                'pbaseline': pbaseline,
-            },
-        }
-    else:
-        prepared_job = {
-            'job_type': 'SRG_TIME_SERIES',
-            'job_parameters': {
-                'granules': granules,
-                'bounds': [min_lon, min_lat, max_lon, max_lat],
-                'process': process,
-                'tbaseline': tbaseline,
-                'pbaseline': pbaseline,
-                'bucket': bucket,
-                'bucket_prefix': bucket_prefix,
-            },
-        }
+    prepared_job = {
+        'job_type': 'SRG_TIME_SERIES',
+        'job_parameters': {
+            'granules': granules,
+            'bounds': [min_lon, min_lat, max_lon, max_lat],
+            'process': process,
+            'tbaseline': tbaseline,
+            'pbaseline': pbaseline,
+        },
+    }
     if name is not None:
         prepared_job['name'] = name
     return hyp3.submit_prepared_jobs(prepared_job)[0]

--- a/scripts/submit_time_series_job.py
+++ b/scripts/submit_time_series_job.py
@@ -82,10 +82,10 @@ def get_args():
         epilog="""
   Examples:
   # Using bounding box:
-  python submit_time_series_job.py 50 2023-01-01 2023-02-01 --bbox -120.0 35.0 -119.0 36.0 --name "KernCounty-Asc050"
+  python submit_time_series_job.py 64 2023-01-01 2023-02-01 --bbox -120.0 35.0 -119.0 36.0 --name "KernCounty-Asc050"
   
   # Using WKT polygon:
-  python submit_time_series_job.py 50 2023-01-01 2023-02-01 --wkt "POLYGON((-120.0 35.0, -119.0 35.0, -119.0 36.0, -120.0 36.0, -120.0 35.0))"
+  python submit_time_series_job.py 64 2023-01-01 2023-02-01 --wkt "POLYGON((-120.0 35.0, -119.0 35.0, -119.0 36.0, -120.0 36.0, -120.0 35.0))"
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/scripts/submit_time_series_job.py
+++ b/scripts/submit_time_series_job.py
@@ -111,7 +111,7 @@ def get_args():
     parser.add_argument('--bucket', help='Bucket Name')
     parser.add_argument(
         '--bucket-prefix',
-        help="Bucket prefix job products will be written to. The argument will be ignored if `--bucket` isn't provided. This argument also allows expansion of job name or job id by using `{name}` and `{job_id}` if contained within the string.",
+        help="Bucket prefix job products will be written to. The argument will be ignored if `--bucket` isn't provided. This argument also allows expansion of job name or job id by using `{name}` and `{job_id}` within the string.",
     )
     parser.add_argument('--process', choices=['sbas', 'ps'], default='sbas', help='Processing strategy (sbas or ps)')
     parser.add_argument('--tbaseline', type=int, default=60, help='Temporal baseline')

--- a/scripts/submit_time_series_job.py
+++ b/scripts/submit_time_series_job.py
@@ -3,6 +3,21 @@ import argparse
 import asf_search
 import hyp3_sdk
 
+def wkt_to_bbox(wkt: str) -> tuple[float, float, float, float]:
+    """Extract bounding box from WKT POLYGON string.
+    Returns: (min_lon, min_lat, max_lon, max_lat)
+    """
+    if not wkt.startswith('POLYGON((') or not wkt.endswith('))'):
+        raise ValueError('WKT must be a POLYGON')
+    
+    # Extract coordinate pairs
+    points_str = wkt[9:-2]  # Strip 'POLYGON((' and '))'
+    coords = [tuple(map(float, point.strip().split())) 
+              for point in points_str.split(',')]
+    
+    lons, lats = zip(*coords)
+    return min(lons), min(lats), max(lons), max(lats)
+
 
 def bbox_to_wkt(min_lon: float, min_lat: float, max_lon: float, max_lat: float) -> str:
     return f'POLYGON(({min_lon} {min_lat},{max_lon} {min_lat},{max_lon} {max_lat},{min_lon} {max_lat},{min_lon} {min_lat}))'
@@ -25,10 +40,10 @@ def get_granules(
         )
         granules.extend(result.properties['sceneName'] for result in results)
     return granules
-
+        
 
 def submit_job(
-    granules: list[str], min_lon: float, min_lat: float, max_lon: float, max_lat: float, hyp3_url: str
+    granules: list[str], min_lon: float, min_lat: float, max_lon: float, max_lat: float, hyp3_url: str, name: str | None = None,
 ) -> hyp3_sdk.Job:
     hyp3 = hyp3_sdk.HyP3(hyp3_url)
     prepared_job = {
@@ -38,19 +53,39 @@ def submit_job(
             'bounds': [min_lon, min_lat, max_lon, max_lat],
         },
     }
+    if name is not None:
+        prepared_job['name'] = name
     return hyp3.submit_prepared_jobs(prepared_job)[0]
 
 
 def get_args():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description='Submit time series job to HyP3',
+        epilog='''
+  Examples:
+  # Using bounding box:
+  python submit_time_series_job.py 50 2023-01-01 2023-02-01 --bbox -120.0 35.0 -119.0 36.0 --name "KernCounty-Asc050"
+  
+  # Using WKT polygon:
+  python submit_time_series_job.py 50 2023-01-01 2023-02-01 --wkt "POLYGON((-120.0 35.0, -119.0 35.0, -119.0 36.0, -120.0 36.0, -120.0 35.0))"
+        ''',
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )    
 
+    # Required positional arguments
     parser.add_argument('path', type=int, help='Path/track number, 1-175')
-    parser.add_argument('min_lon', type=float, help='Western longitude, -180.0 to 180.0')
-    parser.add_argument('min_lat', type=float, help='Southern latitude, -90.0 to 90.0')
-    parser.add_argument('max_lon', type=float, help='Eastern longitude, -180.0 to 180.0')
-    parser.add_argument('max_lat', type=float, help='Northern latitude, -90.0 to 90.0')
     parser.add_argument('start', help='Start of acquisition window, YYYY-MM-DD')
     parser.add_argument('end', help='End of acquisition window, YYYY-MM-DD')
+
+    # Mutually exclusive spatial definition
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--bbox', nargs=4, type=float,
+        metavar=('MIN_LON', 'MIN_LAT', 'MAX_LON', 'MAX_LAT'),
+        help='Bounding box as four floats: min_lon min_lat max_lon max_lat',)
+    group.add_argument('--wkt', help='WKT string for the area of interest')
+
+    # Optional arguments
+    parser.add_argument('--name', help='Name for the job')
     parser.add_argument(
         '--hyp3-deployment',
         choices=['hyp3-lavas', 'hyp3-lavas-test'],
@@ -63,6 +98,21 @@ def get_args():
 
 def main():
     args = get_args()
+
+    if args.wkt:
+        print(f'Parsing WKT: {args.wkt[:50]}...')
+        args.min_lon, args.min_lat, args.max_lon, args.max_lat = wkt_to_bbox(args.wkt)
+    else:
+        args.min_lon, args.min_lat, args.max_lon, args.max_lat = args.bbox
+            
+    print(f'Processing configuration:')
+    print(f'  Path: {args.path}')
+    print(f'  Date range: {args.start} to {args.end}')
+    print(f'  Bounding box: ({args.min_lon:.4f}, {args.min_lat:.4f}) to ({args.max_lon:.4f}, {args.max_lat:.4f})')
+    print(f'  Deployment: {args.hyp3_deployment}')
+    if args.name:
+        print(f'  Job name: {args.name}')
+
     granule_names = get_granules(
         args.path, args.start, args.end, args.min_lon, args.min_lat, args.max_lon, args.max_lat
     )
@@ -71,9 +121,9 @@ def main():
         raise ValueError('No granules found for these search criteria')
 
     hyp3_url = f'https://{args.hyp3_deployment}.asf.alaska.edu'
-    job = submit_job(granule_names, args.min_lon, args.min_lat, args.max_lon, args.max_lat, hyp3_url)
+    job = submit_job(granule_names, args.min_lon, args.min_lat, args.max_lon, args.max_lat, hyp3_url, args.name)
 
-    print(f'\nJob {job.job_id} submitted to {args.hyp3_deployment} for {len(granule_names)} granules')
+    print(f'\nJob {job.job_id}, Name: {job.name}, submitted to {args.hyp3_deployment} for {len(granule_names)} granules')
 
     print(f'\n{hyp3_url}/jobs/{job.job_id}')
     print('\nimport hyp3_sdk')


### PR DESCRIPTION
Hi @mfangaritav & @jhkennedy,

Suggesting some args in job submission. Examples are also written in --help.

I added a new arg that people can pass simply the WKT polygon (`--wkt` flag), rather than the default minlat minlon maxlat maxlon.

Because in my workflow, getting WKT polygon string is easy from navigating on the ASF vertex website. Simply copy and paste the wkt string is straightforward.

For the original minlat minlon maxlat maxlon, I lumped them in that `--bbox` flag. Either 

Also I added that `--name` flag to specify the job name, optional.


Another feature we brought up today, is *we want to play flexibly on the temporal and spatial baselines* when submitting the jobs. I realized that I do not have the power to edit the code. The options (or the core code) is not inside the hyp3-srg repo here. hyp3-srg can only submit the job with those dictionary args into hyp3-sdk. 

But I also don't see the explicit codes inside the [`submit_prepared_jobs`] (https://github.com/ASFHyP3/hyp3-sdk/blob/main/src/hyp3_sdk/hyp3.py#L217C9-L237) in `hyp3-sdk/hyp3.py`. I can only trace down to this point. Please let me know how to do it. Or if it is easier to do it from your side!

Thanks!